### PR TITLE
remove calculated 'Dir' variable for protobuffs plugin, just use './i…

### DIFF
--- a/plugins/protobuffs.mk
+++ b/plugins/protobuffs.mk
@@ -17,10 +17,9 @@ endef
 
 define compile_proto.erl
 	[begin
-		Dir = filename:dirname(filename:dirname(F)),
 		protobuffs_compile:generate_source(F,
-			[{output_include_dir, Dir ++ "/include"},
-				{output_src_dir, Dir ++ "/ebin"}])
+			[{output_include_dir, "./include"},
+				{output_src_dir, "./ebin"}])
 	end || F <- string:tokens("$(1)", " ")],
 	halt().
 endef


### PR DESCRIPTION
…nclude' and './ebin'